### PR TITLE
hw3 userfs: fix type cast compilation error

### DIFF
--- a/2/checker.py
+++ b/2/checker.py
@@ -171,9 +171,13 @@ for test in tests:
 tests = [
 (["ls /"], 0),
 (["ls / | exit 123"], 123),
-(["ls /404"], 1),
 (["ls /404", "echo test"], 0),
 ]
+cmd = "ls /404"
+code = os.WEXITSTATUS(os.system(cmd + ' 2>/dev/null'))
+assert(code != 0)
+tests.append(([cmd], code))
+
 for test in tests:
 	p = open_new_shell()
 	try:

--- a/3/test.c
+++ b/3/test.c
@@ -205,7 +205,7 @@ test_io(void)
 	ufs_close(fd1);
 	bool ok = true;
 	for (size_t i = 0; i < some_size && ok; ++i)
-		ok = ok && buffer[i] == 'a' + i % ('z' - 'a' + 1);
+		ok = ok && buffer[i] == (char)('a' + i % ('z' - 'a' + 1));
 	unit_check(ok, "data is correct");
 
 	ufs_delete("file");

--- a/utils/heap_help/heap_help.c
+++ b/utils/heap_help/heap_help.c
@@ -320,6 +320,8 @@ trace_sym_is_internal(const struct symbol *sym)
 		return true;
 	if (trace_sym_is_func(sym, "_IO_printf"))
 		return true;
+	if (trace_sym_is_func(sym, "_IO_vfscanf"))
+		return true;
 	if (trace_sym_file_starts_with(sym, "libpthread.so"))
 		return true;
 	return false;


### PR DESCRIPTION
A type cast was missing and it triggered a warning on some compilers.